### PR TITLE
fix: reset to pomodoro on completion

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
                 if (diff <= 0)
                 {
                     playCompleteSound();
-                    resetTimer();
+                    resetToPomodoro();
                 } else {
                     updateTimeDisplay(diff);
                 }


### PR DESCRIPTION
When extending the `resetTimer()` with a duration, I forgot to update
one call site. As such, when a pomodoro completes, it displays "NaN:00".